### PR TITLE
preserve tabs in odt document

### DIFF
--- a/odt-custom-styles.lua
+++ b/odt-custom-styles.lua
@@ -37,6 +37,7 @@ end
 function getParaStyled(para, style)
   local startTag, endTag = getParaTags(style)
   local content = startTag .. pandoc.utils.stringify(para) .. endTag
+  content = string.gsub(content, "\t", "<text:tab/>")
   return pandoc.RawBlock('opendocument', content)
 end
 


### PR DESCRIPTION
tabs in odt raw blocks must be represented as `<text:tab/>`, otherwise they get lost